### PR TITLE
fix identical ternary branches

### DIFF
--- a/lib/swig-i18n.js
+++ b/lib/swig-i18n.js
@@ -122,7 +122,7 @@ exports.init = function (translation_thing, config, next) {
 
     parser.on(types.COMMA, function (token) { 
       if ( currentState > 1 && end_is_safe === true) {
-        this.out.push('(' + isDefined('_ctx.', nameSet) + ' ? ' + '_ctx.' + nameSet + ' : ' + isDefined('',nameSet) + ' ? ' + nameSet + ' : "' + nameSet + '")');
+        this.out.push('(' + isDefined('_ctx.', nameSet) + ' ? ' + '_ctx.' + nameSet + ' : ' + isDefined('',nameSet) + ' ? ' + nameSet + ' : "")');
       }
       end_is_safe = true;
       nameSet = '';
@@ -139,7 +139,7 @@ exports.init = function (translation_thing, config, next) {
     
     parser.on('end', function(token) {
       if ( currentState > 1 && end_is_safe === true) {
-        this.out.push('(' + isDefined('_ctx.', nameSet) + ' ? ' + '_ctx.' + nameSet + ' : ' + isDefined('',nameSet) + ' ? ' + nameSet + ' : "' + nameSet + '")');
+        this.out.push('(' + isDefined('_ctx.', nameSet) + ' ? ' + '_ctx.' + nameSet + ' : ' + isDefined('',nameSet) + ' ? ' + nameSet + ' : "")');
         nameSet = '';
      }
     });

--- a/test/swig-i18n.js
+++ b/test/swig-i18n.js
@@ -300,3 +300,28 @@ exports["imperial language mode"] = function(test){
   test.equal(expected, 'foo');
   test.done();
 };
+
+exports["string subsitution with undefined variable"] = function(test){
+
+  this.swig_i18n.init({ TAG_LOOKUP: { es: 'Hola __name__' } });
+  var template = '{% i18n GREET_NAME __name__:name %}Hello __name__{% endi18n%}'; 
+
+  var expected = this.swig.render(template,{
+    locals:{
+      i18n:{language: 'es'}
+    }
+  });
+
+  test.expect(2);
+  test.equal(expected, 'Hello ');
+
+  expected = this.swig.render(template,{
+    locals:{
+      i18n:{language: 'es'},
+			name: 'world'
+    }
+  });
+  test.equal(expected, 'Hello world');
+
+  test.done();
+};


### PR DESCRIPTION
I believe the intent is to return a quoted version of the variable if the variable is not defined.  This is the case in some of the other similar statements in this file.
