### PR TITLE
Feature/active languages

### DIFF
--- a/lib/swig-i18n.js
+++ b/lib/swig-i18n.js
@@ -54,7 +54,6 @@ exports.init = function (translation_thing, config, next) {
   }
 
   swig.setExtension('i18n', function(ctx, tag, default_translation) {
-    //console.log(ctx);
     var language = ctx.i18n ? ctx.i18n.language : 'unknown';
     return translate(tag, language, default_translation);
   });


### PR DESCRIPTION
Adds a config option so that i18n will only respect a language if it appears in the 'activeLanguages' array. This allows us to go ahead with potentially half translated tags without a half translated site.
