### PR TITLE
adding update translations function.

### DIFF
--- a/lib/swig-i18n.js
+++ b/lib/swig-i18n.js
@@ -32,7 +32,7 @@ function isDefined(ctx, match) {
   return build;
 }
 
-function storeTranslations(translation_thing) {
+function setTranslations(translation_thing) {
     translations = typeof(translation_thing) === 'function' ? translation_thing() : translation_thing;
 };
 
@@ -44,12 +44,12 @@ exports.clearCompiledData = function() {
     compiledData = {};
 };
 
-exports.updateTranslations = storeTranslations;
+exports.setTranslations = setTranslations;
 
 exports.init = function (translation_thing, config, next) {
   config = _.extend(global_config, config);
 
-  storeTranslations(translation_thing);
+  setTranslations(translation_thing);
 
   function translate(tag, language, defaultTranslation) {
     if ( (config.imperial_language && config.imperial_language === language && defaultTranslation) ||

--- a/lib/swig-i18n.js
+++ b/lib/swig-i18n.js
@@ -2,6 +2,8 @@ var _       = require('underscore');
 var console = require('console');
 var swig    = require('swig');
 
+var translations = {};
+
 var global_config = {
   imperial_language: 0,
   debug: 0,
@@ -30,6 +32,10 @@ function isDefined(ctx, match) {
   return build;
 }
 
+function storeTranslations(translation_thing) {
+    translations = typeof(translation_thing) === 'function' ? translation_thing() : translation_thing;
+};
+
 exports.compiledData = function() {
     return compiledData;
 };
@@ -38,11 +44,13 @@ exports.clearCompiledData = function() {
     compiledData = {};
 };
 
-exports.init = function (translation_thing, config, next) {
+exports.updateTranslations = storeTranslations;
 
+exports.init = function (translation_thing, config, next) {
   config = _.extend(global_config, config);
-  var translations = typeof(translation_thing) === 'function' ? translation_thing() : translation_thing;
-  
+
+  storeTranslations(translation_thing);
+
   function translate(tag, language, defaultTranslation) {
     if ( (config.imperial_language && config.imperial_language === language && defaultTranslation) ||
             (config.active_languages && !_.contains(config.active_languages, language) && defaultTranslation)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swig-i18n",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "i18n tag for swig template engine",
   "main": "index.js",
   "scripts": {

--- a/test/swig-i18n.js
+++ b/test/swig-i18n.js
@@ -45,7 +45,7 @@ exports["basic usage find updated translation"] = function(test){
 
   test.equal(expected, 'foo');
 
-  this.swig_i18n.updateTranslations({ TAG_LOOKUP: { es: 'bar' } });
+  this.swig_i18n.setTranslations({ TAG_LOOKUP: { es: 'bar' } });
 
   var updated = this.swig.render(template, {locals:{i18n:{language: 'es'}}});
   test.expect(2);

--- a/test/swig-i18n.js
+++ b/test/swig-i18n.js
@@ -36,6 +36,23 @@ exports["basic usage find translation"] = function(test){
   test.done();
 };
 
+exports["basic usage find updated translation"] = function(test){
+
+  this.swig_i18n.init({ TAG_LOOKUP: { es: 'foo' } });
+  var template = '{% i18n TAG_LOOKUP %}Default text{% endi18n%}';
+
+  var expected = this.swig.render(template, {locals:{i18n:{language: 'es'}}});
+
+  test.equal(expected, 'foo');
+
+  this.swig_i18n.updateTranslations({ TAG_LOOKUP: { es: 'bar' } });
+
+  var updated = this.swig.render(template, {locals:{i18n:{language: 'es'}}});
+  test.expect(2);
+  test.equal(updated, 'bar');
+  test.done();
+};
+
 exports["basic usage find translation as a function"] = function(test){
 
   this.swig_i18n.init(function(){return { TAG_LOOKUP: { es: 'foo' } }});


### PR DESCRIPTION
so we can push changes without reinitializing.  also add test.

swig-i18n
✔ basic default usage
✔ basic usage find translation
### ✔ basic usage find updated translation

✔ basic usage find translation as a function
✔ translation tags that start with numbers and end as strings (a numvar!)
✔ basic usage find translation when tag is not found
✔ string subsitution with literal string
✔ string subsitution with context object
✔ string subsitution with dynamic variable via set
✔ string substitution via a dynamic variable passed from data structure
✔ i18n tag works inside macros!
✔ value subsitution on arrays
✔ value as hash lookup
✔ bug to fix set variable autoescape on
✔ bug to fix set variable autoescape off
✔ numbers as assignment
✔ value with array index lookup
✔ value with undef deep nested lookup up should use default
✔ filters are totally possible
✔ imperial language mode
✔ string subsitution with undefined variable
✔ active languages are respected

OK: 29 assertions (52ms)
